### PR TITLE
Add backend and frontend CI workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,31 @@
+name: Backend
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2'
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+      - name: Run tests
+        run: |
+          if [ -d "spec" ]; then
+            bundle exec rspec
+          else
+            bundle exec rails test
+          fi
+

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,34 @@
+name: Frontend
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Run tests
+        run: |
+          if npm run | grep -q "test"; then
+            npm test
+          else
+            echo "No tests configured"
+          fi
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for the Rails backend
- add GitHub Actions workflow for the Node frontend

## Testing
- `bundle install --jobs 4 --retry 3` *(fails: rbenv version `3.2.2` is not installed)*
- `npm ci` *(fails to connect to registry)*

------
https://chatgpt.com/codex/tasks/task_e_6850eff0e5148326ad949de778ac4806